### PR TITLE
Moved entity instance creation to separate method

### DIFF
--- a/LeanMapper/Entity.php
+++ b/LeanMapper/Entity.php
@@ -443,6 +443,19 @@ abstract class Entity
 		return $entities;
 	}
 
+	/**
+	 * Creates entity instance for given row
+	 *
+	 * @param string $class
+	 * @param Row $row
+	 *
+	 * @return mixed
+	 */
+	protected function createEntityInstance($class, Row $row)
+	{
+		return new $class($row, $this->mapper);
+	}
+
 	protected function initDefaults()
 	{
 	}
@@ -468,7 +481,7 @@ abstract class Entity
 			return null;
 		} else {
 			$class = $property->getType();
-			return new $class($row, $this->mapper);
+			return $this->createEntityInstance($class, $row);
 		}
 	}
 
@@ -487,7 +500,7 @@ abstract class Entity
 		foreach ($rows as $row) {
 			$valueRow = $row->referenced($relationship->getTargetTable(), $targetTableFilter, $relationship->getColumnReferencingTargetTable());
 			if ($valueRow !== null) {
-				$value[] = new $class($valueRow, $this->mapper);
+				$value[] = $this->createEntityInstance($class, $valueRow);
 			}
 		}
 		return $this->createCollection($value);
@@ -515,7 +528,7 @@ abstract class Entity
 		} else {
 			$row = reset($rows);
 			$class = $property->getType();
-			return new $class($row, $this->mapper);
+			return $this->createEntityInstance($class, $row);
 		}
 	}
 
@@ -531,7 +544,7 @@ abstract class Entity
 		$class = $property->getType();
 		$value = array();
 		foreach ($rows as $row) {
-			$value[] = new $class($row, $this->mapper);
+			$value[] = $this->createEntityInstance($class, $row);
 		}
 		return $this->createCollection($value);
 	}

--- a/LeanMapper/Repository.php
+++ b/LeanMapper/Repository.php
@@ -199,7 +199,7 @@ abstract class Repository
 		}
 		$result = Result::getInstance($row, $table, $this->connection, $this->mapper);
 		$primaryKey = $this->mapper->getPrimaryKey($this->getTable());
-		return new $entityClass($result->getRow($row->$primaryKey));
+		return $this->createEntityInstance($entityClass, $result->getRow($row->$primaryKey));
 	}
 
 	/**
@@ -222,9 +222,21 @@ abstract class Repository
 		$collection = Result::getInstance($rows, $table, $this->connection, $this->mapper);
 		$primaryKey = $this->mapper->getPrimaryKey($this->getTable());
 		foreach ($rows as $row) {
-			$entities[$row->$primaryKey] = new $entityClass($collection->getRow($row->$primaryKey));
+			$entities[$row->$primaryKey] = $this->createEntityInstance($entityClass, $collection->getRow($row->$primaryKey));
 		}
 		return $this->createCollection($entities);
+    }
+
+	/**
+	 * Create entity instance from given row
+	 *
+	 * @param string $entityClass
+	 * @param Row $row
+	 * @return mixed
+	 */
+	protected function createEntityInstance($entityClass, Row $row)
+	{
+		return new $entityClass($row);
 	}
 
 	/**


### PR DESCRIPTION
This could be the first step to implement simple single table
inheritance. You can override the createEntityInstance() in your
derived Repository/Entity to create subclassed entities depending on some
row property value.

Anyway, it's good to extract entity creation functionalty into seperate
method, I believe.

Really, entity instantiation logic is common for both Repository and
Entity, so we should look for more DRY solution (use Mapper maybe?).
