### PR TITLE
Removed empty queries with nullable relationship.

### DIFF
--- a/LeanMapper/Result.php
+++ b/LeanMapper/Result.php
@@ -547,8 +547,13 @@ class Result implements \Iterator
 		$primaryKey = $this->mapper->getPrimaryKey($table);
 		if ($filter === null) {
 			if (!isset($this->referenced[$key])) {
-				$data = $this->createTableSelection($table)->where('%n.%n IN %in', $table, $primaryKey, $this->extractIds($viaColumn))
+				$referencingIds = $this->extractIds($viaColumn);
+				if (empty($referencingIds)) {
+					$data = array();
+				} else {				
+					$data = $this->createTableSelection($table)->where('%n.%n IN %in', $table, $primaryKey, $referencingIds)
 						->fetchAll();
+				}
 				$this->referenced[$key] = self::getInstance($data, $table, $this->connection, $this->mapper, $key);
 			}
 		} else {


### PR DESCRIPTION
Situation: An entity with nullable one reference. If you find only one entity that has this property is set to null, it generates the empty query.
## Example

``` php
$book = new Book;
$book->author = NULL;
$book->title = "The book written by anonym";
$bookRepository->persist($book);

///

$bookRepository->find($book->id);
```

Generates :

``` sql
SELECT `file`.* 
FROM `file` 
WHERE `file`.`id` IN (NULL)
```
