### PR TITLE
Improved Connection - added hasFilter function

### DIFF
--- a/LeanMapper/Connection.php
+++ b/LeanMapper/Connection.php
@@ -54,10 +54,10 @@ class Connection extends DibiConnection
 		$this->filters[$name] = array($callback, $this->translateWiringSchema($wiringSchema));
 	}
 
-    /**
-     * @param string $name
-     * @return bool
-     */
+	/**
+	 * @param string $name
+	 * @return bool
+	 */
 	public function hasFilter($name)
 	{
 		try {


### PR DESCRIPTION
Pokud není možné registrovat filtr při vytváření connection z důvodu kruhové závislosti je potřeba filter registrovat až za běhu (třeba v repository) a je nutné mít možnost zkontrolovat jeho existenci.

Příklad: potřebujeme zaregistrovat překladové filtry, které využívají LanguageFacade (má za úkol držet seznam jazyků, který načteme při inicializaci a zněhož dále získáváme pro překlady požadovaný jazyk). LanguageFacade (LanguageRepository) má závislost na Connection (kruhová závislost Filter > Connection > Filter). Překladové filtry zaregistruji v Abstract TranslationRepository, který využíváme pro překladové repositáře. TranslationRepository se může použít za 1 request vícekrát a connection by vyhazoval při registerFilter - InvalidArgumentException. Pomocí této vyjímky by se to dalo ošetřit, ale registrace filtru tuto vyjímku vyhazuje při více scénářích.
