### PR TITLE
Avoided redefining PHP variable regex

### DIFF
--- a/LeanMapper/Connection.php
+++ b/LeanMapper/Connection.php
@@ -22,6 +22,13 @@ use LeanMapper\Exception\InvalidArgumentException;
 class Connection extends DibiConnection
 {
 
+	const PHP_VARIABLE_FIRST_LETTER = '[a-zA-Z_\x7f-\xff]';
+
+	const PHP_VARIABLE_OTHER_LETTER = '[a-zA-Z0-9_\x7f-\xff]';
+
+	const PHP_VARIABLE = '[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*';
+
+
 	const WIRE_ENTITY = 1;
 
 	const WIRE_PROPERTY = 2;
@@ -42,7 +49,7 @@ class Connection extends DibiConnection
 	 */
 	public function registerFilter($name, $callback, $wiringSchema = null)
 	{
-		if (!preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#', $name)) {
+		if (!preg_match('#^'.self::PHP_VARIABLE.'$#', $name)) {
 			throw new InvalidArgumentException("Invalid filter name given: '$name'. For filter names apply the same rules as for function names in PHP.");
 		}
 		if (isset($this->filters[$name])) {

--- a/LeanMapper/Reflection/PropertyFactory.php
+++ b/LeanMapper/Reflection/PropertyFactory.php
@@ -11,6 +11,7 @@
 
 namespace LeanMapper\Reflection;
 
+use LeanMapper\Connection;
 use LeanMapper\Exception\InvalidAnnotationException;
 use LeanMapper\Exception\UtilityClassException;
 use LeanMapper\IMapper;
@@ -48,10 +49,10 @@ class PropertyFactory
 		$matches = array();
 		$matched = preg_match('~
 			^(null\|)?
-			((?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+)
+			((?:\\\\?'.Connection::PHP_VARIABLE.')+)
 			(\[\])?
 			(\|null)?\s+
-			(\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)
+			(\$'.Connection::PHP_VARIABLE.')
 			(?:\s+=\s*(?:
 				"((?:\\\\"|[^"])+)" |  # double quoted string
 				\'((?:\\\\\'|[^\'])+)\' |  # single quoted string
@@ -102,7 +103,7 @@ class PropertyFactory
 
 		if (isset($matches[10])) {
 			$flagMatches = array();
-			preg_match_all('~m:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)\s*(?:\(([^)]*)\))?~', $matches[10], $flagMatches, PREG_SET_ORDER);
+			preg_match_all('~m:('.Connection::PHP_VARIABLE.')\s*(?:\(([^)]*)\))?~', $matches[10], $flagMatches, PREG_SET_ORDER);
 			foreach ($flagMatches as $match) {
 				$flag = $match[1];
 				$flagArgument = (isset($match[2]) and $match[2] !== '') ? $match[2] : null;

--- a/LeanMapper/Reflection/PropertyFilters.php
+++ b/LeanMapper/Reflection/PropertyFilters.php
@@ -11,6 +11,7 @@
 
 namespace LeanMapper\Reflection;
 
+use LeanMapper\Connection;
 use LeanMapper\Exception\InvalidAnnotationException;
 
 /**
@@ -42,7 +43,7 @@ class PropertyFilters
 			$filters = $targetedArgs = array();
 			foreach (preg_split('#\s*,\s*#', $set) as $filter) {
 				$matches = array();
-				preg_match('~^([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:#(.*))?$~', $filter, $matches);
+				preg_match('~^('.Connection::PHP_VARIABLE.')(?:#(.*))?$~', $filter, $matches);
 				if (empty($matches)) {
 					throw new InvalidAnnotationException("Malformed filter name given: '$filter'.");
 				}

--- a/LeanMapper/Reflection/PropertyMethods.php
+++ b/LeanMapper/Reflection/PropertyMethods.php
@@ -11,6 +11,7 @@
 
 namespace LeanMapper\Reflection;
 
+use LeanMapper\Connection;
 use LeanMapper\Exception\InvalidAnnotationException;
 
 /**
@@ -50,7 +51,7 @@ class PropertyMethods
 			if ($method === '') {
 				continue;
 			}
-			if (!preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#', $method)) {
+			if (!preg_match('#^'.Connection::PHP_VARIABLE.'$#', $method)) {
 				throw new InvalidAnnotationException("Malformed access method name given: '$method'.");
 			}
 			if ($counter === 1) {

--- a/LeanMapper/Reflection/PropertyPasses.php
+++ b/LeanMapper/Reflection/PropertyPasses.php
@@ -11,6 +11,7 @@
 
 namespace LeanMapper\Reflection;
 
+use LeanMapper\Connection;
 use LeanMapper\Exception\InvalidAnnotationException;
 
 /**
@@ -43,7 +44,7 @@ class PropertyPasses
 			if ($pass === '') {
 				continue;
 			}
-			if (!preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#', $pass)) {
+			if (!preg_match('#^'.Connection::PHP_VARIABLE.'$#', $pass)) {
 				throw new InvalidAnnotationException("Malformed method pass name given: '$pass'.");
 			}
 			if ($counter === 1) {

--- a/LeanMapper/Reflection/PropertyValuesEnum.php
+++ b/LeanMapper/Reflection/PropertyValuesEnum.php
@@ -11,6 +11,7 @@
 
 namespace LeanMapper\Reflection;
 
+use LeanMapper\Connection;
 use LeanMapper\Exception\InvalidAnnotationException;
 use ReflectionClass;
 
@@ -37,7 +38,7 @@ class PropertyValuesEnum
 	public function __construct($definition, EntityReflection $reflection)
 	{
 		$matches = array();
-		preg_match('#^((?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+|self|static|parent)::([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)\*$#', $definition, $matches);
+		preg_match('#^((?:\\\\?'.Connection::PHP_VARIABLE.')+|self|static|parent)::('.Connection::PHP_VARIABLE_FIRST_LETTER.Connection::PHP_VARIABLE_OTHER_LETTER.'+)\*$#', $definition, $matches);
 		if (empty($matches)) {
 			throw new InvalidAnnotationException("Invalid enumeration definition given: '$definition'.");
 		}


### PR DESCRIPTION
Nadefinovat regulární výraz pro PHP proměnnou jako konstantu. Možná je to zbytečné, ale zdá se mi, že to může do budoucna ušetřit nějaké `typo` a že by to mělo být definované jen jednou. Nejsem si však jist, že definování v `LeanMapper\Connection` je ta správná cesta, ačkoli mě nenapadla vhodnější třída.