### PR TITLE
Repository: improved performance of getTable()

### DIFF
--- a/LeanMapper/Repository.php
+++ b/LeanMapper/Repository.php
@@ -325,7 +325,7 @@ abstract class Repository
 					return $this->table = $table;
 				}
 			}
-			return $this->mapper->getTableByRepositoryClass(get_called_class());
+			$this->table = $this->mapper->getTableByRepositoryClass(get_called_class());
 		}
 		return $this->table;
 	}


### PR DESCRIPTION
Multiple calls of `Repository::getTable()` does no longer result in multiple calls of `IMapper::getTableByRepositoryClass()` (useful when your mapper methods are resource- and time-consuming)