### PR TITLE
Updated link to travis build in readme.md (master -> develop)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 Lean Mapper
 ===========
 
-[![Build Status](https://travis-ci.org/Tharos/LeanMapper.svg?branch=master)](https://travis-ci.org/Tharos/LeanMapper)
+[![Build Status](https://travis-ci.org/Tharos/LeanMapper.svg?branch=develop)](https://travis-ci.org/Tharos/LeanMapper)
 
 Lean Mapper is a tiny ORM based on powerful [dibi database abstraction library](http://dibiphp.com) for PHP 5.
 


### PR DESCRIPTION
@castamir Přišlo by mi užitečnější mít to nasměrované na `develop`, protože master je u nás víc stable a ten vždycky musí procházet… Co myslíš?