### PR TITLE
Allow to use all class constants in m:enum, not only prefixed ones.

### DIFF
--- a/src/LeanMapper/Reflection/PropertyValuesEnum.php
+++ b/src/LeanMapper/Reflection/PropertyValuesEnum.php
@@ -39,14 +39,15 @@ class PropertyValuesEnum
     {
         $matches = [];
         preg_match(
-            '#^((?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+|self|static|parent)::([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)\*$#',
+            '#^((?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+|self|static|parent)::([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)?\*$#',
             $definition,
             $matches
         );
         if (empty($matches)) {
             throw new InvalidAnnotationException("Invalid enumeration definition given: '$definition'.");
         }
-        list(, $class, $prefix) = $matches;
+        $class = $matches[1];
+        $prefix = array_key_exists(2, $matches) ? $matches[2] : '';
 
         if ($class === 'self' or $class === 'static') {
             $constants = $reflection->getConstants();

--- a/tests/LeanMapper/Entity.enum.2.phpt
+++ b/tests/LeanMapper/Entity.enum.2.phpt
@@ -21,9 +21,20 @@ class BaseEntity extends Entity
 
 }
 
+class WhenEnum {
+
+    const NEVER = 'never';
+
+    const ONCE = 'once';
+
+    const EACH_TIME = 'eachTime';
+
+}
+
 /**
  * @property int $id
  * @property string $state m:enum(self::STATE_*)
+ * @property string $when m:enum(WhenEnum::*)
  */
 class Project extends BaseEntity
 {
@@ -65,4 +76,27 @@ Assert::throws(
     },
     'LeanMapper\Exception\InvalidValueException',
     "Given value is not from possible values enumeration in property 'state' in entity Project."
+);
+
+//////////
+
+Assert::equal(
+    [
+        'NEVER' => 'never',
+        'ONCE' => 'once',
+        'EACH_TIME' => 'eachTime',
+    ],
+    $project->getEnumValues('when')
+);
+
+$project->when = WhenEnum::ONCE;
+
+Assert::equal(WhenEnum::ONCE, $project->when);
+
+Assert::throws(
+    function () use ($project) {
+        $project->when = 'onceUponATime';
+    },
+    'LeanMapper\Exception\InvalidValueException',
+    "Given value is not from possible values enumeration in property 'when' in entity Project."
 );


### PR DESCRIPTION
Hi!

here is a little change of LeanMapper. With this change `m:enum(SomeClass::*)` can be used instead of only `m:enum(SomeClass::SOME_*)`.

It is very useful when you have Enum classes like this one:
```php
class WhenEnum {
    const NEVER = 'never';
    const ONCE = 'once';
    const EACH_TIME = 'eachTime';
}
```

So the entity could look like this:
```php
/**
 * @property int $id
 * @property string $when m:enum(WhenEnum::*)
 */
class MyEntity extends \LeanMapper\Entity {
}
```

What do you think about that? It'll be great for me if it could be merged.

I'm looking forward to your answer! 

Thanks, Jan