### PR TITLE
EntityReflection: property name must be unique

### DIFF
--- a/src/LeanMapper/Reflection/EntityReflection.php
+++ b/src/LeanMapper/Reflection/EntityReflection.php
@@ -179,6 +179,12 @@ class EntityReflection extends \ReflectionClass
                 foreach (AnnotationsParser::parseAnnotationValues($annotationType, $member->getDocComment()) as $definition) {
                     $property = PropertyFactory::createFromAnnotation($annotationType, $definition, $member, $this->mapper);
                     // collision check
+                    if (isset($this->properties[$property->getName()])) {
+                        throw new InvalidStateException(
+                            "Duplicated property '{$property->getName()}' in entity {$this->getName()}. Please fix property name."
+                        );
+                    }
+
                     $column = $property->getColumn();
                     if ($column !== null and $property->isWritable()) {
                         if (isset($columns[$column])) {

--- a/tests/LeanMapper/Entity.propertyCollision.phpt
+++ b/tests/LeanMapper/Entity.propertyCollision.phpt
@@ -1,0 +1,78 @@
+<?php
+
+use LeanMapper\Entity;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+//////////
+
+/**
+ * @property string $web (website)
+ * @property string $site (website)
+ */
+class AuthorWithDuplicatedColumn extends Entity
+{
+}
+
+Assert::exception(
+    function () {
+        $reflection = AuthorWithDuplicatedColumn::getReflection();
+    },
+    'LeanMapper\Exception\InvalidStateException',
+    "Mapping collision in property 'site' (column 'website') in entity AuthorWithDuplicatedColumn. Please fix mapping or make chosen properties read only (using property-read)."
+);
+
+//////////
+
+/**
+ * @property int $id
+ * @property string $id
+ */
+class AuthorWithDuplicatedProperty1 extends Entity
+{
+}
+
+Assert::exception(
+    function () {
+        $reflection = AuthorWithDuplicatedProperty1::getReflection();
+    },
+    'LeanMapper\Exception\InvalidStateException',
+    "Duplicated property 'id' in entity AuthorWithDuplicatedProperty1. Please fix property name."
+);
+
+//////////
+
+/**
+ * @property int $id
+ * @property string $id (name)
+ */
+class AuthorWithDuplicatedProperty2 extends Entity
+{
+}
+
+Assert::exception(
+    function () {
+        $reflection = AuthorWithDuplicatedProperty2::getReflection();
+    },
+    'LeanMapper\Exception\InvalidStateException',
+    "Duplicated property 'id' in entity AuthorWithDuplicatedProperty2. Please fix property name."
+);
+
+//////////
+
+/**
+ * @property int $id
+ * @property-read string $id
+ */
+class AuthorWithDuplicatedReadProperty extends Entity
+{
+}
+
+Assert::exception(
+    function () {
+        $reflection = AuthorWithDuplicatedReadProperty::getReflection();
+    },
+    'LeanMapper\Exception\InvalidStateException',
+    "Duplicated property 'id' in entity AuthorWithDuplicatedReadProperty. Please fix property name."
+);


### PR DESCRIPTION
Narazil jsem na to, že Lean Mapper dovoluje vytvoření entity s duplicitními názvy properties. Bylo by fajn v takové situaci vyhodit nějaké upozornění.