### PR TITLE
Result: fixed UNION for complex queries (LIMIT, ORDER BY,...)

### DIFF
--- a/tests/LeanMapper/Entity.relatedKeys.limit.phpt
+++ b/tests/LeanMapper/Entity.relatedKeys.limit.phpt
@@ -1,0 +1,80 @@
+<?php
+
+use LeanMapper\Connection;
+use LeanMapper\Entity;
+use LeanMapper\Fluent;
+use LeanMapper\Reflection\Property;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$connection->onEvent[] = function ($event) use (&$queries, &$i) {
+    $queries[] = $event->sql;
+};
+
+//////////
+
+/**
+ * @property int $id
+ * @property Book[] $oldestBook m:belongsToMany(#union) m:filter(limit#1,orderBy#pubdate)
+ */
+class Author extends Entity
+{
+}
+
+/**
+ * @property int $id
+ */
+class Book extends Entity
+{
+}
+
+class AuthorRepository extends LeanMapper\Repository
+{
+
+    public function findAll()
+    {
+        return $this->createEntities(
+            $this->createFluent()->fetchAll()
+        );
+    }
+
+}
+
+////////////////////
+////////////////////
+
+$connection->registerFilter(
+    'limit',
+    function (Fluent $statement, $limit) {
+        $statement->limit($limit);
+    }
+);
+
+$connection->registerFilter(
+    'orderBy',
+    function (Fluent $statement, $column) {
+        $statement->orderBy('%n', $column);
+    }
+);
+
+$authorRepository = new AuthorRepository($connection, $mapper, $entityFactory);
+
+$authors = $authorRepository->findAll();
+$author = reset($authors);
+
+$author->oldestBook;
+
+Assert::equal(
+    [
+        'SELECT [author].* FROM [author]',
+        'SELECT * FROM (' . implode(') UNION SELECT * FROM (', array(
+            'SELECT [book].* FROM [book] WHERE [book].[author_id] = 1 ORDER BY [pubdate] LIMIT 1',
+            'SELECT [book].* FROM [book] WHERE [book].[author_id] = 2 ORDER BY [pubdate] LIMIT 1',
+            'SELECT [book].* FROM [book] WHERE [book].[author_id] = 3 ORDER BY [pubdate] LIMIT 1',
+            'SELECT [book].* FROM [book] WHERE [book].[author_id] = 4 ORDER BY [pubdate] LIMIT 1',
+            'SELECT [book].* FROM [book] WHERE [book].[author_id] = 5 ORDER BY [pubdate] LIMIT 1',
+        )) . ')'
+    ],
+    $queries
+);

--- a/tests/LeanMapper/Entity.relatedKeys.phpt
+++ b/tests/LeanMapper/Entity.relatedKeys.phpt
@@ -71,7 +71,7 @@ Assert::equal(
     [
         'SELECT [author].* FROM [author]',
         'SELECT [book].* FROM [book] WHERE [book].[author_id] IN (1, 2, 3, 4, 5)',
-        'SELECT [book].* FROM [book] WHERE [book].[author_id] = 1 UNION SELECT [book].* FROM [book] WHERE [book].[author_id] = 2 UNION SELECT [book].* FROM [book] WHERE [book].[author_id] = 3 UNION SELECT [book].* FROM [book] WHERE [book].[author_id] = 4 UNION SELECT [book].* FROM [book] WHERE [book].[author_id] = 5',
+        'SELECT * FROM (SELECT [book].* FROM [book] WHERE [book].[author_id] = 1) UNION SELECT * FROM (SELECT [book].* FROM [book] WHERE [book].[author_id] = 2) UNION SELECT * FROM (SELECT [book].* FROM [book] WHERE [book].[author_id] = 3) UNION SELECT * FROM (SELECT [book].* FROM [book] WHERE [book].[author_id] = 4) UNION SELECT * FROM (SELECT [book].* FROM [book] WHERE [book].[author_id] = 5)',
     ],
     $queries
 );


### PR DESCRIPTION
Našel jsem 2 bugy při použití UNION strategie.

1) pokud do dotazu filtrem přidám klauzuli `LIMIT`, rozbije se generování dotazu a použije se jen jeho první část, tj. místo dotazu

   ``` sql
   (SELECT [book].* FROM [book] WHERE [book].[author_id] = 1 LIMIT 1)
   UNION
   (SELECT [book].* FROM [book] WHERE [book].[author_id] = 2 LIMIT 1)
   ```
   se vygeneruje jen

   ``` sql
   SELECT [book].* FROM [book] WHERE [book].[author_id] = 1 LIMIT 1
   ```

   takže nedojde k načtení všech dat. Problém způsobil pravděpodobně tento [commit](https://github.com/dg/dibi/commit/c26201c75d9ec30dcb23720a7753efc9f6727c2a) v dibi. Pokud se výsledek nelimituje, je vygenerovaný dotaz v pořádku.

2. druhý bug souvisí s SQLite - jednotlivé UNION části nesmí být v SQLite zabaleny do závorek - to však znemožňuje použití komplexnějších dotazů - pokud do dotazu doplníme `LIMIT` nebo `ORDER BY` vyhodí nám SQLite chybu. Řešit se to dá pomocí subselectů:

``` sql
SELECT * FROM (SELECT [book].* FROM [book] WHERE [book].[author_id] = 1 ORDER BY [pubdate])
UNION
SELECT * FROM (SELECT [book].* FROM [book] WHERE [book].[author_id] = 2 ORDER BY [pubdate])
```