### PR TITLE
DefaultMapper: added $defaultEntityNamespace to constructor

### DIFF
--- a/src/LeanMapper/DefaultMapper.php
+++ b/src/LeanMapper/DefaultMapper.php
@@ -21,11 +21,21 @@ use LeanMapper\Exception\InvalidStateException;
 class DefaultMapper implements IMapper
 {
 
-    /** @var string */
-    protected $defaultEntityNamespace = 'Model\Entity';
+    /** @var string|null */
+    protected $defaultEntityNamespace;
 
     /** @var string */
     protected $relationshipTableGlue = '_';
+
+
+
+    /**
+     * @param  string|null
+     */
+    public function __construct($defaultEntityNamespace = 'Model\Entity')
+    {
+        $this->defaultEntityNamespace = $defaultEntityNamespace;
+    }
 
 
 

--- a/tests/LeanMapper/DefaultMapper.phpt
+++ b/tests/LeanMapper/DefaultMapper.phpt
@@ -30,3 +30,67 @@ Assert::equal('author_id', $mapper->getRelationshipColumn('book', 'author'));
 Assert::equal('reviewer_id', $mapper->getRelationshipColumn('book', 'author', 'reviewer'));
 
 Assert::equal('author', $mapper->getTableByRepositoryClass('Model\Repository\AuthorRepository'));
+
+//////////
+
+$mapper = new DefaultMapper('App\Entities');
+
+Assert::equal('App\Entities\Author', $mapper->getEntityClass('author'));
+
+Assert::equal('App\Entities\Book', $mapper->getEntityClass('book'));
+
+//////////
+
+$mapper = new DefaultMapper(null);
+
+Assert::equal('Author', $mapper->getEntityClass('author'));
+
+Assert::equal('Book', $mapper->getEntityClass('book'));
+
+//////////
+
+class MyMapper extends DefaultMapper
+{
+    public function __construct(array $mapping)
+    {
+        parent::__construct();
+        // some stuff
+    }
+}
+
+$mapper = new MyMapper([]);
+
+Assert::equal('Model\Entity\Author', $mapper->getEntityClass('author'));
+
+Assert::equal('Model\Entity\Book', $mapper->getEntityClass('book'));
+
+//////////
+
+class MyMapper2 extends DefaultMapper
+{
+    public function __construct()
+    {
+        $this->defaultEntityNamespace = 'MyMapper2';
+    }
+}
+
+$mapper = new MyMapper2();
+
+Assert::equal('MyMapper2\Author', $mapper->getEntityClass('author'));
+
+Assert::equal('MyMapper2\Book', $mapper->getEntityClass('book'));
+
+//////////
+
+// Old unsupported usage
+//
+// class MyMapper3 extends DefaultMapper
+// {
+//     protected $defaultEntityNamespace = 'MyMapper3';
+// }
+
+// $mapper = new MyMapper3();
+
+// Assert::equal('MyMapper3\Author', $mapper->getEntityClass('author'));
+
+// Assert::equal('MyMapper3\Book', $mapper->getEntityClass('book'));

--- a/tests/LeanMapper/Entity.singleTableInheritance.phpt
+++ b/tests/LeanMapper/Entity.singleTableInheritance.phpt
@@ -10,7 +10,10 @@ require_once __DIR__ . '/../bootstrap.php';
 class Mapper extends LeanMapper\DefaultMapper
 {
 
-    protected $defaultEntityNamespace = null;
+    public function __construct()
+    {
+        $this->defaultEntityNamespace = null;
+    }
 
 
 

--- a/tests/LeanMapper/PrimaryEqualsForeign.phpt
+++ b/tests/LeanMapper/PrimaryEqualsForeign.phpt
@@ -44,7 +44,10 @@ class AuthorContract extends Entity
 class Mapper extends DefaultMapper
 {
 
-    protected $defaultEntityNamespace = null;
+    public function __construct()
+    {
+        $this->defaultEntityNamespace = null;
+    }
 
 
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,18 +32,11 @@ if (!copy(__DIR__ . '/db/library-ref.sq3', TEMP_DIR . '/library.sq3')) {
     exit(1);
 }
 
-class TestMapper extends DefaultMapper
-{
-
-    protected $defaultEntityNamespace = null;
-
-}
-
 $connection = new Connection([
     'driver' => 'sqlite3',
     'database' => TEMP_DIR . '/library.sq3',
 ]);
 
-$mapper = new TestMapper;
+$mapper = new DefaultMapper(null);
 
 $entityFactory = new DefaultEntityFactory;


### PR DESCRIPTION
Umožňuje předat `$defaultEntityNamespace` přímo do konstruktoru, takže odpadá nutnost dědit, jen abychom změnili výchozí namespace.

``` php
$mapper = new LeanMapper\DefaultMapper('App\Model\Entities`);
```

Změna by měla být plně zpětně kompatibilní (doufám), viz test. Pak jsem ještě opravil anotaci u property (`$defaultEntityNamespace` může být `null`).