### PR TITLE
Entity: fixed enumeration checking for nullable properties

### DIFF
--- a/src/LeanMapper/Entity.php
+++ b/src/LeanMapper/Entity.php
@@ -677,7 +677,7 @@ abstract class Entity
             if ($value !== null) {
                 settype($value, $property->getType());
             }
-            if ($property->containsEnumeration() and !$property->isValueFromEnum($value)) {
+            if ($value !== null and $property->containsEnumeration() and !$property->isValueFromEnum($value)) {
                 throw new InvalidValueException(
                     "Given value is not from possible values enumeration in property '{$property->getName()}' in entity " . get_called_class() . '.'
                 );

--- a/tests/LeanMapper/Entity.enum.3.phpt
+++ b/tests/LeanMapper/Entity.enum.3.phpt
@@ -1,0 +1,44 @@
+<?php
+
+use PDO as DbLayer;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+//////////
+
+/**
+ * @property int $id
+ * @property string|null $state m:enum(self::STATE_*)
+ * @property string $finalState m:enum(self::STATE_*)
+ */
+class Author extends LeanMapper\Entity
+{
+
+    const STATE_ACTIVE = 'active';
+
+    const STATE_INACTIVE = 'inactive';
+
+    const STATE_DELETED = 'deleted';
+
+}
+
+
+//////////
+
+$author = new Author;
+
+$author->state = Author::STATE_ACTIVE;
+Assert::equal(Author::STATE_ACTIVE, $author->state);
+
+$author->state = NULL;
+Assert::equal(NULL, $author->state);
+
+$author->finalState = Author::STATE_DELETED;
+Assert::equal(Author::STATE_DELETED, $author->finalState);
+
+Assert::exception(function () use ($author) {
+
+    $author->finalState = NULL;
+
+}, 'LeanMapper\Exception\InvalidValueException', "Property 'finalState' in entity Author cannot be null.");


### PR DESCRIPTION
Commit (pravděpodobně) 013247e075cb366e77363008a82c831e1d04a567 způsobil, že nullable položkám, které mají zároveň `m:enum`, nelze přiřadit `null`, tj. následující kód skončí chybou, protože si LM myslí, že `null` nespadá do výčtu:

```php
/**
 * @property int $id
 * @property string|null $state m:enum(self::STATE_*)
 */
class Author extends LeanMapper\Entity
{
    const STATE_ACTIVE = 'active';
    const STATE_INACTIVE = 'inactive';
}

$author = new Author;
$author->state = NULL; // throws exception
```