### PR TITLE
Fixes problem with passthru setter

### DIFF
--- a/src/LeanMapper/Entity.php
+++ b/src/LeanMapper/Entity.php
@@ -673,8 +673,7 @@ abstract class Entity
         if ($property->isBasicType()) {
             if ($pass !== null) {
                 $value = $this->$pass($value);
-            }
-            if ($value !== null) {
+            } elseif ($value !== null) {
                 settype($value, $property->getType());
             }
             if ($property->containsEnumeration() and !$property->isValueFromEnum($value)) {


### PR DESCRIPTION
So in 3.1 you changed  passthru getter so that you can specify the type in the callable, but you forgot that the passthru setter must do the same...

Let me demonstrate on a very common use case where one uses JSON as string in the DB and wants an array in the Entity.

Simplest Entity:
```php
/**
 * @property int $id
 * @property array|NULL $attrs m:passThru(jsonDecodeData|jsonEncodeData)
 */
class Foo extends LeanMapper\Entity
{

	protected function jsonEncodeData($data)
	{
		return !empty($data) ? Json::encode($data) : NULL;
	}

	protected function jsonDecodeData($data)
	{
		return !empty($data) ? Json::decode($data, Json::FORCE_ARRAY) : [];
	}

}
```

You set array, and you expect to get arrays as well:
```php
$entity->attrs = ['foo' => 'bar',];
var_dump($entity->attrs);
```
Whoa! `Warning: json_decode() expects parameter 1 to be string, array given`.
Why? because after the setting calls to `Entity::getModifiedRowData` return:
```
attrs => array (1)
0 => "{"foo":"bar"}" (13)
```
instead of expected:
```
attrs => "{"foo":"bar"}" (13)
```
It is caused by calling `settype` with the returned string  and "array" as the type.

This also obviously leads to invalid SQL like
```sql
UPDATE `products` 
SET `attrs`={'foo':'bar'}
WHERE ...
```
while it should be
```sql
UPDATE `products` 
SET `attrs`="{'foo':'bar'}"
WHERE ...
```
(it is not escaped properly).
