### PR TITLE
PropertyFactory: m:default is not marked as default value

### DIFF
--- a/src/LeanMapper/Reflection/PropertyFactory.php
+++ b/src/LeanMapper/Reflection/PropertyFactory.php
@@ -231,6 +231,11 @@ class PropertyFactory
                         } elseif (isset($matches[3]) and $matches[3] !== '') {
                             $customDefault = $matches[3];
                         }
+
+                        if ($customDefault !== null) {
+                            $hasDefaultValue = true;
+                        }
+
                         break;
                     default:
                         if (array_key_exists($flag, $customFlags)) {

--- a/tests/LeanMapper/Entity.property.parser.phpt
+++ b/tests/LeanMapper/Entity.property.parser.phpt
@@ -52,6 +52,7 @@ $entityReflection = $book->getReflection($mapper);
 Assert::false($entityReflection->getEntityProperty('pubDate')->hasDefaultValue());
 Assert::false($entityReflection->getEntityProperty('myName')->hasDefaultValue());
 Assert::equal('foo3', $entityReflection->getEntityProperty('description')->getDefaultValue());
+Assert::true($entityReflection->getEntityProperty('web')->hasDefaultValue());
 Assert::equal('foo4', $entityReflection->getEntityProperty('web')->getDefaultValue());
 Assert::true($entityReflection->getEntityProperty('web')->hasCustomFlag('custom-flag'));
 Assert::equal('value', $entityReflection->getEntityProperty('web')->getCustomFlagValue('custom-flag'));


### PR DESCRIPTION
Konstrukce `$entityReflection->getEntityProperty('xyz')->hasDefaultValue()` vrací FALSE, pokud výchozí hodnotu uvedeme v `m:default`. Stará syntaxe `$property = value` funguje v pořádku.