### PR TITLE
PropertyFactory: m:default fixes

### DIFF
--- a/src/LeanMapper/Reflection/PropertyFactory.php
+++ b/src/LeanMapper/Reflection/PropertyFactory.php
@@ -93,18 +93,6 @@ class PropertyFactory
         } elseif (isset($matches[8]) and $matches[8] !== '') {
             $defaultValue = $matches[8];
         }
-        if ($defaultValue !== null) {
-            $hasDefaultValue = true;
-            try {
-                $defaultValue = self::fixDefaultValue($defaultValue, $propertyType, $isNullable);
-            } catch (InvalidAnnotationException $e) {
-                throw new InvalidAnnotationException(
-                    "Invalid property definition given: @$annotationType $annotation in entity {$entityReflection->getName()}, " . lcfirst(
-                        $e->getMessage()
-                    )
-                );
-            }
-        }
         $column = $mapper !== null ? $mapper->getColumn($entityReflection->getName(), $name) : $name;
         if (isset($matches[9]) and $matches[9] !== '') {
             $column = $matches[9];
@@ -117,14 +105,12 @@ class PropertyFactory
         $propertyValuesEnum = null;
         $customFlags = [];
         $customColumn = null;
-        $customDefault = null;
 
         if (isset($matches[10])) {
-            $flagMatches = [];
-            preg_match_all('~m:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff-]*)\s*(?:\(([^)]*)\))?~', $matches[10], $flagMatches, PREG_SET_ORDER);
+            preg_match_all('~m:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff-]*)\s*(\(((?>[^)(]+|(?2))*)\))?~', $matches[10], $flagMatches, PREG_SET_ORDER);
             foreach ($flagMatches as $match) {
                 $flag = $match[1];
-                $flagArgument = (isset($match[2]) and $match[2] !== '') ? $match[2] : null;
+                $flagArgument = (isset($match[3]) and $match[3] !== '') ? $match[3] : null;
 
                 switch ($flag) {
                     case 'hasOne':
@@ -200,7 +186,7 @@ class PropertyFactory
                         $customColumn = $flagArgument;
                         break;
                     case 'default':
-                        if ($customDefault !== null) {
+                        if ($defaultValue !== null) {
                             throw new InvalidAnnotationException(
                                 "Multiple default value settings found in property definition: @$annotationType $annotation in entity {$entityReflection->getName()}."
                             );
@@ -225,15 +211,11 @@ class PropertyFactory
                             throw new \Exception;
                         }
                         if (isset($matches[1]) and $matches[1] !== '') {
-                            $customDefault = str_replace('\"', '"', $matches[1]);
+                            $defaultValue = str_replace('\"', '"', $matches[1]);
                         } elseif (isset($matches[2]) and $matches[2] !== '') {
-                            $customDefault = str_replace("\\'", "'", $matches[2]);
+                            $defaultValue = str_replace("\\'", "'", $matches[2]);
                         } elseif (isset($matches[3]) and $matches[3] !== '') {
-                            $customDefault = $matches[3];
-                        }
-
-                        if ($customDefault !== null) {
-                            $hasDefaultValue = true;
+                            $defaultValue = $matches[3];
                         }
 
                         break;
@@ -248,8 +230,21 @@ class PropertyFactory
             }
         }
 
+        if ($defaultValue !== null) {
+            $hasDefaultValue = true;
+
+            try {
+                $defaultValue = self::fixDefaultValue($defaultValue, $propertyType, $isNullable);
+            } catch (InvalidAnnotationException $e) {
+                throw new InvalidAnnotationException(
+                    "Invalid property definition given: @$annotationType $annotation in entity {$entityReflection->getName()}, " . lcfirst(
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+
         $column = $customColumn ?: $column;
-        $defaultValue = $customDefault ?: $defaultValue;
 
         return new Property(
             $name,

--- a/tests/LeanMapper/Entity.defaults.2.phpt
+++ b/tests/LeanMapper/Entity.defaults.2.phpt
@@ -1,0 +1,164 @@
+<?php
+
+use LeanMapper\Entity;
+use LeanMapper\Reflection\EntityReflection;
+use LeanMapper\Reflection\PropertyFactory;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+////////////////////
+
+class EmptyEntity extends Entity
+{
+}
+
+$entityReflection = new EntityReflection(new EmptyEntity());
+
+////////////////////
+
+///// booleans
+
+$property = PropertyFactory::createFromAnnotation('property', 'bool $active m:default(true)', $entityReflection);
+
+Assert::equal(true, $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'bool $active m:default(TrUe)', $entityReflection);
+
+Assert::equal(true, $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'bool $active m:default(FALSE)', $entityReflection);
+
+Assert::equal(false, $property->getDefaultValue());
+
+Assert::exception(
+    function () use ($entityReflection) {
+        PropertyFactory::createFromAnnotation('property', 'bool $active m:default(foobar)', $entityReflection);
+    },
+    'LeanMapper\Exception\InvalidAnnotationException',
+    "Invalid property definition given: @property bool \$active m:default(foobar) in entity EmptyEntity, property of type boolean cannot have default value 'foobar'."
+);
+
+///// integers
+
+$property = PropertyFactory::createFromAnnotation('property', 'int $count m:default(10)', $entityReflection);
+
+Assert::equal(10, $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'int $count m:default(0x1F)', $entityReflection);
+
+Assert::equal(31, $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'int $count m:default(0123)', $entityReflection);
+
+Assert::equal(83, $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'int $count m:default("12")', $entityReflection);
+
+Assert::equal(12, $property->getDefaultValue());
+
+Assert::exception(
+    function () use ($entityReflection) {
+        PropertyFactory::createFromAnnotation('property', 'int $count m:default(true)', $entityReflection);
+    },
+    'LeanMapper\Exception\InvalidAnnotationException',
+    "Invalid property definition given: @property int \$count m:default(true) in entity EmptyEntity, property of type integer cannot have default value 'true'."
+);
+
+$property = PropertyFactory::createFromAnnotation('property', 'int $count m:default(-12)', $entityReflection);
+
+Assert::equal(-12, $property->getDefaultValue());
+
+///// floats
+
+$property = PropertyFactory::createFromAnnotation('property', 'float $count m:default(10.5)', $entityReflection);
+
+Assert::equal(10.5, $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'float $count m:default(-2.2e-3)', $entityReflection);
+
+Assert::equal(-0.0022, $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'float $count m:default("-2.4e-3")', $entityReflection);
+
+Assert::equal(-0.0024, $property->getDefaultValue());
+
+///// strings
+
+$property = PropertyFactory::createFromAnnotation('property', 'string $title m:default(test)', $entityReflection);
+
+Assert::equal('test', $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'string $title m:default(foo bar)', $entityReflection);
+
+Assert::equal('foo', $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'string $title m:default("foo bar")', $entityReflection);
+
+Assert::equal('foo bar', $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', "string \$title m:default(McDonald's)", $entityReflection);
+
+Assert::equal("McDonald's", $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', "string \$title m:default('McDonald\'s restaurant')", $entityReflection);
+
+Assert::equal("McDonald's restaurant", $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', "string \$title m:default('McDonald\\'s restaurant')", $entityReflection);
+
+Assert::equal("McDonald's restaurant", $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'string $title m:default("foo\"b\'ar")', $entityReflection);
+
+Assert::equal('foo"b\'ar', $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'string $title m:default("")', $entityReflection);
+
+Assert::equal('', $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', "string \$title m:default('')", $entityReflection);
+
+Assert::equal('', $property->getDefaultValue());
+
+///// arrays
+
+$property = PropertyFactory::createFromAnnotation('property', 'array $list m:default(array())', $entityReflection);
+
+Assert::equal([], $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'array $list m:default(ARRAY())', $entityReflection);
+
+Assert::equal([], $property->getDefaultValue());
+
+Assert::exception(
+    function () use ($entityReflection) {
+        PropertyFactory::createFromAnnotation('property', 'array $list m:default(ARRAY)', $entityReflection);
+    },
+    'LeanMapper\Exception\InvalidAnnotationException',
+    "Invalid property definition given: @property array \$list m:default(ARRAY) in entity EmptyEntity, property of type array cannot have default value 'ARRAY'."
+);
+
+///// null
+
+$property = PropertyFactory::createFromAnnotation('property', 'string|null $title m:default(null)', $entityReflection);
+
+Assert::equal(null, $property->getDefaultValue());
+
+$property = PropertyFactory::createFromAnnotation('property', 'string|null $title m:default(NULL)', $entityReflection);
+
+Assert::equal(null, $property->getDefaultValue());
+
+///// objects
+
+$property = PropertyFactory::createFromAnnotation('property', 'NULL|DateTime $created m:default(null)', $entityReflection);
+
+Assert::equal(null, $property->getDefaultValue());
+
+Assert::exception(
+    function () use ($entityReflection) {
+        PropertyFactory::createFromAnnotation('property', 'DateTime $created m:default(10)', $entityReflection);
+    },
+    'LeanMapper\Exception\InvalidAnnotationException',
+    "Invalid property definition given: @property DateTime \$created m:default(10) in entity EmptyEntity, only properties of basic types may have default values specified."
+);

--- a/tests/LeanMapper/Entity.defaults.3.phpt
+++ b/tests/LeanMapper/Entity.defaults.3.phpt
@@ -1,0 +1,36 @@
+<?php
+
+use LeanMapper\Entity;
+use LeanMapper\Reflection\EntityReflection;
+use LeanMapper\Reflection\PropertyFactory;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+////////////////////
+
+class EmptyEntity extends Entity
+{
+}
+
+$entityReflection = new EntityReflection(new EmptyEntity());
+
+////////////////////
+
+///// conflicts
+
+Assert::exception(
+    function () use ($entityReflection) {
+        PropertyFactory::createFromAnnotation('property', 'int $number m:default(10) m:default(20)', $entityReflection);
+    },
+    'LeanMapper\Exception\InvalidAnnotationException',
+    "Multiple default value settings found in property definition: @property int \$number m:default(10) m:default(20) in entity EmptyEntity."
+);
+
+Assert::exception(
+    function () use ($entityReflection) {
+        PropertyFactory::createFromAnnotation('property', 'int $number = 20 m:default(10)', $entityReflection);
+    },
+    'LeanMapper\Exception\InvalidAnnotationException',
+    "Multiple default value settings found in property definition: @property int \$number = 20 m:default(10) in entity EmptyEntity."
+);


### PR DESCRIPTION
- added support for nested brackets in flags (allows `m:default(array())`)
- added converting of values (`m:default(20)` is same as `int $number = 20`)
- improved detection of duplicated default values
  - `int $number = 20 m:default(10)` or `int $number m:default(10) m:default(20)` throws exception