### PR TITLE
Fixes property parsing being invoked inefficiently

### DIFF
--- a/src/LeanMapper/Reflection/EntityReflection.php
+++ b/src/LeanMapper/Reflection/EntityReflection.php
@@ -27,7 +27,7 @@ class EntityReflection extends \ReflectionClass
     private $mapper;
 
     /** @var Property[] */
-    private $properties;
+    private $properties = null;
 
     /** @var array */
     private $getters;
@@ -54,7 +54,6 @@ class EntityReflection extends \ReflectionClass
     {
         parent::__construct($argument);
         $this->mapper = $mapper;
-        $this->parseProperties();
         $this->initGettersAndSetters();
     }
 
@@ -68,6 +67,9 @@ class EntityReflection extends \ReflectionClass
      */
     public function getEntityProperty($name)
     {
+        if ($this->properties === null) {
+            $this->parseProperties();
+        }
         return isset($this->properties[$name]) ? $this->properties[$name] : null;
     }
 
@@ -80,6 +82,9 @@ class EntityReflection extends \ReflectionClass
      */
     public function getEntityProperties()
     {
+        if ($this->properties === null) {
+            $this->parseProperties();
+        }
         return $this->properties;
     }
 

--- a/src/LeanMapper/Reflection/EntityReflection.php
+++ b/src/LeanMapper/Reflection/EntityReflection.php
@@ -30,10 +30,10 @@ class EntityReflection extends \ReflectionClass
     private $properties = null;
 
     /** @var array */
-    private $getters;
+    private $getters = null;
 
     /** @var array */
-    private $setters;
+    private $setters = null;
 
     /** @var Aliases|null */
     private $aliases;
@@ -54,7 +54,6 @@ class EntityReflection extends \ReflectionClass
     {
         parent::__construct($argument);
         $this->mapper = $mapper;
-        $this->initGettersAndSetters();
     }
 
 
@@ -140,6 +139,9 @@ class EntityReflection extends \ReflectionClass
      */
     public function getGetter($name)
     {
+        if ($this->getters === null) {
+            $this->initGettersAndSetters();
+        }
         return isset($this->getters[$name]) ? $this->getters[$name] : null;
     }
 
@@ -152,6 +154,9 @@ class EntityReflection extends \ReflectionClass
      */
     public function getGetters()
     {
+        if ($this->getters === null) {
+            $this->initGettersAndSetters();
+        }
         return $this->getters;
     }
 
@@ -165,6 +170,9 @@ class EntityReflection extends \ReflectionClass
      */
     public function getSetter($name)
     {
+        if ($this->setters === null) {
+            $this->initGettersAndSetters();
+        }
         return isset($this->setters[$name]) ? $this->setters[$name] : null;
     }
 

--- a/tests/LeanMapper/Entity.hasMany.inversed.phpt
+++ b/tests/LeanMapper/Entity.hasMany.inversed.phpt
@@ -77,8 +77,10 @@ Assert::equal([1, 3], fetchBooksId($tag->books));
 
 Assert::exception(function () use ($mapper) {
     $reflection = BrokenTag::getReflection($mapper);
+    $reflection->getEntityProperties();
 }, 'LeanMapper\Exception\InvalidAnnotationException', 'It doesn\'t make sense to combine #inversed and hardcoded relationship table in entity BrokenTag.');
 
 Assert::exception(function () use ($mapper) {
     $reflection = BrokenAuthor::getReflection($mapper);
+    $reflection->getEntityProperties();
 }, 'LeanMapper\Exception\InvalidAnnotationException', 'It doesn\'t make sense to have #inversed in belongsToMany relationship in entity BrokenAuthor.');

--- a/tests/LeanMapper/Entity.propertyCollision.phpt
+++ b/tests/LeanMapper/Entity.propertyCollision.phpt
@@ -18,6 +18,7 @@ class AuthorWithDuplicatedColumn extends Entity
 Assert::exception(
     function () {
         $reflection = AuthorWithDuplicatedColumn::getReflection();
+        $reflection->getEntityProperties();
     },
     'LeanMapper\Exception\InvalidStateException',
     "Mapping collision in property 'site' (column 'website') in entity AuthorWithDuplicatedColumn. Please fix mapping or make chosen properties read only (using property-read)."
@@ -36,6 +37,7 @@ class AuthorWithDuplicatedProperty1 extends Entity
 Assert::exception(
     function () {
         $reflection = AuthorWithDuplicatedProperty1::getReflection();
+        $reflection->getEntityProperties();
     },
     'LeanMapper\Exception\InvalidStateException',
     "Duplicated property 'id' in entity AuthorWithDuplicatedProperty1. Please fix property name."
@@ -54,6 +56,7 @@ class AuthorWithDuplicatedProperty2 extends Entity
 Assert::exception(
     function () {
         $reflection = AuthorWithDuplicatedProperty2::getReflection();
+        $reflection->getEntityProperties();
     },
     'LeanMapper\Exception\InvalidStateException',
     "Duplicated property 'id' in entity AuthorWithDuplicatedProperty2. Please fix property name."
@@ -72,6 +75,7 @@ class AuthorWithDuplicatedReadProperty extends Entity
 Assert::exception(
     function () {
         $reflection = AuthorWithDuplicatedReadProperty::getReflection();
+        $reflection->getEntityProperties();
     },
     'LeanMapper\Exception\InvalidStateException',
     "Duplicated property 'id' in entity AuthorWithDuplicatedReadProperty. Please fix property name."


### PR DESCRIPTION
The problem:
- property parsing was being triggered multiple times for the same files, exponentially in relation to the ancestry depth

The solution:
- do not call property parsing in the constructor
- parse properties on first access

The result:
- the complexity of parsing is reduced from **exponential** complexity to **linear** complexity, in relation to the depth of ancestry of the final entity classes

---

The test that shows the problem can be seen here:
https://github.com/dakujem/LeanMapper/blob/props-parsing-hell/tests/LeanMapper/EntityReflection.parsing.phpt

The tests for the fixed version can be found here:
https://github.com/dakujem/LeanMapper/blob/props-parsing-test/tests/LeanMapper/EntityReflection.parsing.phpt

I did not include the test intentionally, as it requires a static hook in the EntityReflection class or changing the visibility of methods in the class (private->protected). I am open to discussion.