### PR TITLE
Update Tester and Docs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,14 @@
 		"nette/bootstrap": "~2.2",
 		"nette/di": "~2.2",
 		"nette/robot-loader": "~2.2",
-		"nette/tester": "~1.0"
+		"nette/tester": "^2"
+	},
+	"scripts": {
+		"test": "tester tests -c tests/php-unix.ini",
+		"test-local": "tester tests -C"
+	},
+	"scripts-descriptions": {
+		"test": "Run all tests using UNIX configuration.",
+		"test-local": "Run all tests using local PHP configuration."
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,20 @@ Lean Mapper is a tiny ORM based on powerful [Dibi database abstraction library](
 
 See [www.leanmapper.com](http://www.leanmapper.com) for more informations, usage examples and documentation.
 
+
+Contributions & Testing
+-------
+
+The unit tests can be run using the following composer command:\
+`composer test`
+
+To use local PHP configuration, the following command can be used:\
+`composer test-local`
+
+> Note:\
+> json, pdo, tokenizer and sqlite3 PHP extensions are needed to run the tests.
+
+
 License
 -------
 


### PR DESCRIPTION
Changes:
- Updated _Tester_ to version v2 to enable for `-C` switch (see below)
- Added section to readme about testing
- Added 2 _Composer_ commands for testing:
    - `composer test` (run all tests)
    - `composer test-local` (run all tests using local PHP configuration, via the `-C` _Tester_ switch)

Maybe some info about contribution can be added by you.

Also, what about the following sentence ??
> "This library is no longer actively developed." ...
