### PR TITLE
Result: addToReferencing() ignores duplicated values

### DIFF
--- a/src/LeanMapper/Repository.php
+++ b/src/LeanMapper/Repository.php
@@ -275,6 +275,17 @@ abstract class Repository
                             $value,
                             -$count
                         );
+                    } elseif ($driver instanceof \Dibi\Drivers\Sqlite3Driver) {
+                        $this->connection->query(
+                            'DELETE FROM %n WHERE [rowid] IN (SELECT [rowid] FROM %n WHERE %n = ? AND %n = ? LIMIT %i)',
+                            $relationshipTable,
+                            $relationshipTable,
+                            $columnReferencingSourceTable,
+                            $entity->$idField,
+                            $columnReferencingTargetTable,
+                            $value,
+                            -$count
+                        );
                     } else {
                         $this->connection->query(
                             'DELETE FROM %n WHERE %n = ? AND %n = ? %lmt',

--- a/src/LeanMapper/Result.php
+++ b/src/LeanMapper/Result.php
@@ -560,6 +560,13 @@ class Result implements \Iterator
     public function addToReferencing(array $values, $table, $viaColumn = null, Filtering $filtering = null, $strategy = self::STRATEGY_IN)
     {
         $result = $this->getReferencingResult($table, $viaColumn, $filtering, $strategy);
+
+        foreach ($result as $key => $entry) {
+            if (array_diff_assoc($values, $entry) === []) {
+                return;
+            }
+        }
+
         $result->addDataEntry($values);
         unset($this->index[spl_object_hash($result)]);
     }

--- a/tests/LeanMapper/Entity.hasManyManagement.phpt
+++ b/tests/LeanMapper/Entity.hasManyManagement.phpt
@@ -86,3 +86,27 @@ $bookRepository->persist($book);
 $bookRepository->persist($book);
 
 Assert::equal([1, 2], $connection->query('SELECT [tag_id] FROM [book_tag] WHERE [book_id] = %i', 2)->fetchPairs());
+
+////////////////////
+
+$book = $bookRepository->find(2);
+
+$book->addToTags(1);
+$bookRepository->persist($book);
+
+$book->addToTags(1);
+$bookRepository->persist($book);
+
+Assert::equal([1, 2], $connection->query('SELECT [tag_id] FROM [book_tag] WHERE [book_id] = %i', 2)->fetchPairs());
+
+////////////////////
+
+$book = $bookRepository->find(2);
+
+$book->removeFromTags(1);
+$bookRepository->persist($book);
+
+$book->removeFromTags(1);
+$bookRepository->persist($book);
+
+Assert::equal([2], $connection->query('SELECT [tag_id] FROM [book_tag] WHERE [book_id] = %i', 2)->fetchPairs());


### PR DESCRIPTION
Following code

```php
$book->addToTags(1);
$bookRepository->persist($book);

$book->addToTags(1);
$bookRepository->persist($book);
```

leads to `Dibi\UniqueConstraintViolationException`.