### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/tests/libs/DummyDrivers.php
+++ b/tests/libs/DummyDrivers.php
@@ -34,12 +34,12 @@ class ResultDummyDriver implements \Dibi\ResultDriver
 
     public function fetch($assoc)
     {
-        $raw = array_slice($this->data, $this->position, 1, TRUE);
+        $raw = array_slice($this->data, $this->position, 1, true);
         $data = reset($raw);
         $this->position++;
 
         if (!is_array($raw)) {
-            return FALSE;
+            return false;
         }
 
         if ($assoc) {

--- a/tools/code-checker.php
+++ b/tools/code-checker.php
@@ -25,8 +25,8 @@ set_time_limit(0);
 $checker = new Nette\CodeChecker\Checker;
 $tasks = Nette\CodeChecker\Tasks::class;
 
-$checker->readOnly = TRUE;
-$checker->showProgress = FALSE;
+$checker->readOnly = true;
+$checker->showProgress = false;
 
 $checker->addTask([$tasks, 'controlCharactersChecker']);
 $checker->addTask([$tasks, 'bomFixer']);


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!