### PR TITLE
Repository: creating entities uses table from parameter

### DIFF
--- a/src/LeanMapper/Repository.php
+++ b/src/LeanMapper/Repository.php
@@ -353,7 +353,7 @@ abstract class Repository
         }
         $entities = [];
         $collection = Result::createInstance($rows, $table, $this->connection, $this->mapper);
-        $primaryKey = $this->mapper->getPrimaryKey($this->getTable());
+        $primaryKey = $this->mapper->getPrimaryKey($table);
         if ($entityClass !== null) {
             foreach ($rows as $dibiRow) {
                 $entity = $this->entityFactory->createEntity(


### PR DESCRIPTION
Method createEntities have parameter $table, but the primary key retrieval function did not use it.
No tests, sorry.