### PR TITLE
Fixed compatibility with robot-loader 3.2.3+

### DIFF
--- a/src/LeanMapper/Bridges/Nette/DI/LeanMapperExtension.php
+++ b/src/LeanMapper/Bridges/Nette/DI/LeanMapperExtension.php
@@ -81,7 +81,12 @@ class LeanMapperExtension extends Nette\DI\CompilerExtension
 
         if ($config['scanDirs']) {
             $robot = new RobotLoader;
-            $robot->setCacheStorage(new Nette\Caching\Storages\DevNullStorage);
+
+            // back compatibility to robot loader of version  < 3.0
+            if (method_exists($robot, 'setCacheStorage')) {
+                $robot->setCacheStorage(new Nette\Caching\Storages\DevNullStorage);
+            }
+
             $robot->addDirectory($config['scanDirs']);
             $robot->acceptFiles = '*.php';
             $robot->rebuild();


### PR DESCRIPTION
Fixes #152 
Fixes calling of removed setCacheStorage in robot-loader 3.2.3+ with backward compatibility

REF: https://github.com/nette/robot-loader/commit/6cce320cc93e1a250e48218c2459c5f65f0ad69c