### PR TITLE
PHP 8.1 fixes - both phpstan & tests

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,13 +4,19 @@ on: [push, pull_request]
 
 jobs:
     phpstan:
-        name: PHPStan
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+
+            fail-fast: false
+
+        name: PHP ${{ matrix.php }} PHPStan
         steps:
             - uses: actions/checkout@v2
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: ${{ matrix.php }}
                   coverage: none
 
             - run: composer install --no-interaction

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: ['7.2', '7.3', '7.4', '8.0']
+                php: ['7.2', '7.3', '7.4', '8.0', '8.1']
 
             fail-fast: false
 

--- a/src/LeanMapper/Connection.php
+++ b/src/LeanMapper/Connection.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace LeanMapper;
 
+use Dibi\Row as DibiRow;
 use LeanMapper\Exception\InvalidArgumentException;
 
 /**
@@ -94,7 +95,7 @@ class Connection extends \Dibi\Connection
     /**
      * Creates new instance of Fluent
      *
-     * @return Fluent
+     * @return Fluent<int, DibiRow>
      */
     public function command(): \Dibi\Fluent
     {

--- a/src/LeanMapper/Entity.php
+++ b/src/LeanMapper/Entity.php
@@ -761,7 +761,7 @@ abstract class Entity
      * @param Property|string $property micro-optimalization
      * @throws InvalidMethodCallException
      */
-    protected function assignEntityToProperty(?Entity $entity = null, $property):void
+    protected function assignEntityToProperty(?Entity $entity, $property):void
     {
         if ($entity !== null) {
             $this->useMapper($entity->mapper);

--- a/src/LeanMapper/Fluent.php
+++ b/src/LeanMapper/Fluent.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace LeanMapper;
 
 use Closure;
+use Dibi\Row as DibiRow;
 use LeanMapper\Exception\InvalidArgumentException;
 
 /**
@@ -76,6 +77,7 @@ class Fluent extends \Dibi\Fluent
 
     /**
      * @param array<mixed> $args
+     * @return Fluent<int, DibiRow>
      */
     public function createSelect(?array $args = null): self
     {
@@ -106,6 +108,7 @@ class Fluent extends \Dibi\Fluent
 
     /**
      * @param array<int|string>|null $keys
+     * @return Fluent<int, DibiRow>
      * @throws InvalidArgumentException
      */
     public function setRelatedKeys(?array $keys): self

--- a/src/LeanMapper/Reflection/EntityReflection.php
+++ b/src/LeanMapper/Reflection/EntityReflection.php
@@ -114,6 +114,7 @@ class EntityReflection extends \ReflectionClass
     /**
      * Gets parent entity's reflection
      */
+    #[\ReturnTypeWillChange]
     public function getParentClass(): ?self
     {
         return ($reflection = parent::getParentClass()) ? new self($reflection->getName(), $this->mapper, $this->entityReflectionProvider) : null;
@@ -125,6 +126,7 @@ class EntityReflection extends \ReflectionClass
      *
      * @return string|false
      */
+    #[\ReturnTypeWillChange]
     public function getDocComment()
     {
         if ($this->docComment === null) {

--- a/src/LeanMapper/Repository.php
+++ b/src/LeanMapper/Repository.php
@@ -75,6 +75,9 @@ abstract class Repository
     }
 
 
+    /**
+     * @return Fluent<int, DibiRow>
+     */
     protected function createFluent(/*$filterArg1, $filterArg2, ...*/): Fluent
     {
         $table = $this->getTable();

--- a/src/LeanMapper/Result.php
+++ b/src/LeanMapper/Result.php
@@ -901,6 +901,7 @@ class Result implements \Iterator
 
     /**
      * @param  array<int|string>|null $relatedKeys
+     * @return Fluent<int, DibiRow>
      */
     private function createTableSelection(string $table, ?array $relatedKeys = null): Fluent
     {
@@ -926,6 +927,7 @@ class Result implements \Iterator
 
 
     /**
+     * @param  Fluent<int, DibiRow> $statement
      * @throws InvalidArgumentException
      */
     private function applyFiltering(Fluent $statement, Filtering $filtering): ?FilteringResultDecorator

--- a/src/LeanMapper/Result.php
+++ b/src/LeanMapper/Result.php
@@ -616,6 +616,7 @@ class Result implements \Iterator
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $key = current($this->keys);
@@ -632,6 +633,7 @@ class Result implements \Iterator
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return current($this->keys);

--- a/src/LeanMapper/ResultProxy.php
+++ b/src/LeanMapper/ResultProxy.php
@@ -55,6 +55,7 @@ class ResultProxy implements \Iterator
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->result->current();
@@ -70,6 +71,7 @@ class ResultProxy implements \Iterator
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->result->key();

--- a/src/LeanMapper/Row.php
+++ b/src/LeanMapper/Row.php
@@ -221,7 +221,7 @@ class Row
     }
 
 
-    public function setReferencedRow(?self $row = null, string $viaColumn): void
+    public function setReferencedRow(?self $row, string $viaColumn): void
     {
         $this->referencedRows[$viaColumn] = $row;
     }


### PR DESCRIPTION
In #162 one issue has been reported by PHPStan.

However, for PHP 8.1 there were some more issues - both for PHPStan (missing typehint for `Fluent` iterable) and tester (incompatible return typehints that needed to be "fixed" by PHP attribute).

I also extended Github Actions to run tests with PHP 8.1 and extended static analysis to also run with different PHP versions.